### PR TITLE
Drop 0.12 support in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-  - '0.12'
   - '4'
   - '5'
   - '6'
+  - 'node'
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
0.12 builds were failing because 0.12 is old and snazzy uses template strings.  Weeee. The `node` travis version is a pointer to the latest supported node on travis. 