### PR TITLE
feat: add markdown-it-github-headings (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Usage: sitedown [source] [options]
     --pretty              use directory indexes for pretty URLs (default: true)
     --layout, -l          path to layout file
     --el, -e              css selector for target element (default: ".markdown-body")
+    --github-headings, -g add anchors to headings just like GitHub (default: false)
     --silent, -s          make less noise during build
     --watch, -w           watch a directory or file (experimental)
     --version, -v         show version information
@@ -63,12 +64,13 @@ Usage: sitedown [source] [options]
 var sitedown = require('sitedown')
 
 var options = {
-  source: '.',            // path to source directory               default: cwd
-  build: 'build',         // path to build directory                default: 'build' in cwd
-  pretty: true,           // use directory indexes for pretty URLs  default: true
-  el: '.markdown-body',   // css selector for target element        default: '.markdown-body'
-  layout: 'layout.html',  // path to layout                         default: none
-  silent: false           // make less noise during build           default: false
+  source: '.',            // path to source directory                 default: cwd
+  build: 'build',         // path to build directory                  default: 'build' in cwd
+  pretty: true,           // use directory indexes for pretty URLs    default: true
+  el: '.markdown-body',   // css selector for target element          default: '.markdown-body'
+  layout: 'layout.html',  // path to layout                           default: none
+  githubHeadings: false   // add anchors to headings just like GitHub default: false
+  silent: false           // make less noise during build             default: false
 }
 
 sitedown(options, function (err) {

--- a/bin.js
+++ b/bin.js
@@ -26,6 +26,14 @@ var clopts = require('cliclopts')([
     help: 'path to layout file'
   },
   {
+    name: 'github-headings',
+    abbr: 'g',
+    alias: 'githubHeadings',
+    help: 'add anchors to headings just like GitHub',
+    boolean: true,
+    default: false
+  },
+  {
     name: 'silent',
     abbr: 's',
     help: 'make less noise during build',

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "markdown-it-deflist": "^2.0.1",
     "markdown-it-emoji": "^1.2.0",
     "markdown-it-footnote": "^3.0.1",
+    "markdown-it-github-headings": "^1.0.1",
     "markdown-it-ins": "^2.0.0",
     "markdown-it-mark": "^2.0.0",
     "markdown-it-sub": "^1.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,14 @@ var customElementLayout = '<title></title><main class="i-love-spiderman"></main>
 test('markdown to html', function (t) {
   var file = path.join(__dirname, 'fixtures', 'md', 'README.md')
   var html = sitedown.mdToHtml(file)
-  t.equals(html, generatedIndex, 'conversion lgtm')
+  t.equals(html, generatedIndexLgtm, 'conversion lgtm')
+  t.end()
+})
+
+test('markdown to html with heading anchors IDs', function (t) {
+  var file = path.join(__dirname, 'fixtures', 'md', 'README.md')
+  var html = sitedown.mdToHtml(file, true)
+  t.equals(html, generatedIndexLgtmWithAnchors, 'conversion lgtm')
   t.end()
 })
 
@@ -214,6 +221,37 @@ test('site generation - custom element', function (t) {
   }
 })
 
+test('site generation - prefix heading IDs and add anchor links', function (t) {
+  var opts = {
+    source: path.join(__dirname, 'fixtures', 'md'),
+    build: path.join(__dirname, 'build'),
+    silent: true,
+    pretty: false,
+    githubHeadings: true
+  }
+
+  rimraf(opts.build, generateSite)
+
+  function generateSite () {
+    sitedown(opts, function (err) {
+      t.error(err, 'ran without errors')
+
+      var index = fs.readFileSync(path.join(opts.build, 'index.html'), enc)
+
+      t.ok(index, 'README.md converted to index.html')
+      t.equals(index, indexContentWithPrefixAndAnchors, 'produced expected output')
+
+      rimraf(opts.build, function (err) {
+        t.error(err, 'cleanup')
+        t.end()
+      })
+    })
+  }
+})
+
+var generatedIndexLgtm = '<h1>TESTING!</h1>\n'
+var generatedIndexLgtmWithAnchors = '<h1><a id="testing" class="anchor" href="#testing" aria-hidden="true"><svg aria-hidden="true" class="octicon octicon-link" height="16" version="1.1" viewbox="0 0 16 16" width="16"><path d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></a>TESTING!</h1>\n'
+
 var generatedIndex = '<h1>TESTING!</h1>\n'
 var generatedRewrite = '<title></title><main class="markdown-body"><p><a href="rewrite/">rewrite me</a></p>\n</main>'
 var generatedRewriteReadme = '<title></title><main class="markdown-body"><p><a href="/">rewrite me right</a></p>\n</main>'
@@ -222,6 +260,10 @@ var generatedNoRewriteHttps = '<title></title><main class="markdown-body"><p><a 
 var generatedNoRewriteHttp = '<title></title><main class="markdown-body"><p><a href="http://github.com/hypermodules/sitedown/README.md">or me!</a></p>\n</main>'
 var generatedRewriteHttpfooMd = '<title></title><main class="markdown-body"><p><a href="httpfoo/">rewrite</a></p>\n</main>'
 var indexContent = '<!DOCTYPE html>\n<html lang="en">\n<head>\n  <meta charset="utf-8">\n  <meta name="viewport" content="width=device-width, initial-scale=1">\n  <title>TESTING!</title>\n  <link rel="stylesheet" href="https://unpkg.com/style.css">\n</head>\n<body>\n  <main class="markdown-body"><h1>TESTING!</h1>\n</main>\n</body>\n</html>\n'
+
+var coolSvgLinkIcon = '<svg aria-hidden="true" class="octicon octicon-link" height="16" version="1.1" viewbox="0 0 16 16" width="16"><path d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"/></svg>'
+var indexContentWithPrefixAndAnchors = '<!DOCTYPE html>\n<html lang="en">\n<head>\n  <meta charset="utf-8">\n  <meta name="viewport" content="width=device-width, initial-scale=1">\n  <title>TESTING!</title>\n  <link rel="stylesheet" href="https://unpkg.com/style.css">\n</head>\n<body>\n  <main class="markdown-body"><h1><a id="testing" class="anchor" href="#testing" aria-hidden="true">' + coolSvgLinkIcon + '</a>TESTING!</h1>\n</main>\n</body>\n</html>\n'
+
 var customElementContent = '<html><title>TESTING!</title><body class="custom-element"><h1>TESTING!</h1>\n</body></html>\n'
 var rewriteContent = '<!DOCTYPE html>\n<html lang="en">\n<head>\n  <meta charset="utf-8">\n  <meta name="viewport" content="width=device-width, initial-scale=1">\n  <title></title>\n  <link rel="stylesheet" href="https://unpkg.com/style.css">\n</head>\n<body>\n  <main class="markdown-body"><p><a href="rewrite/">rewrite me</a></p>\n</main>\n</body>\n</html>\n'
 var rewriteUglyContent = '<!DOCTYPE html>\n<html lang="en">\n<head>\n  <meta charset="utf-8">\n  <meta name="viewport" content="width=device-width, initial-scale=1">\n  <title></title>\n  <link rel="stylesheet" href="https://unpkg.com/style.css">\n</head>\n<body>\n  <main class="markdown-body"><p><a href="rewrite.html">rewrite me</a></p>\n</main>\n</body>\n</html>\n'


### PR DESCRIPTION
- Also add marky-deep-links to the default and site layouts.

Note that this will now add the little svg link icons next to each header (similar to GitHub):
![image](https://user-images.githubusercontent.com/360233/30012679-6582e0e2-9107-11e7-8aff-ec1f28451c20.png)

They show all the time instead of just on hover though... maybe that should be updated in style.css?